### PR TITLE
Changed os.startfile to a system command

### DIFF
--- a/src/FileSystem.py
+++ b/src/FileSystem.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 import os
+import webbrowser
+
 
 SAVE_FILE_NAME = "save.json"
 ICONS_FOLDER_NAME = "icons"
@@ -39,6 +41,24 @@ def font(font_name: str) -> str | None:
     """Returns the absolute path of given font. Returns None if the font does not exist."""
     path = os.path.join(FONTS_FOLDER, font_name)
     return os.path.abspath(path) if os.path.exists(path) else None
+
+def open_task(task_url: str, task_name: str, task_file, platform: str):
+    commands = []
+
+    if url := task_url:
+        urls = url.split(',')
+        func_1 = lambda *x, urls=urls, name=task_name: [webbrowser.open(url.strip()) for url in
+                                                                urls]
+        commands.append(func_1)
+
+    if file := task_file:
+        abs_file_path = os.path.abspath(file)
+        if platform in ('win32',):
+            func_2 = lambda *x, name=task_name: os.startfile(abs_file_path)
+        elif platform in ('linux', 'darwin'):
+            func_2 = lambda *x, name=task_name: os.system(f'xdg-open {abs_file_path}')
+        commands.append(func_2)
+    return commands
 
 
 # for testing purposes

--- a/src/FileSystem.py
+++ b/src/FileSystem.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 
 SAVE_FILE_NAME = "save.json"

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import time
-import webbrowser
 from functools import partial
 from typing import Callable
 
@@ -682,21 +681,7 @@ class CustomWindow(QWidget):
                     button.setStyleSheet("background-color: #DADADA; border-radius: 12px;")
                     task_layout.addWidget(button)
 
-                    commands = []
-
-                    if url := task.url():
-                        urls = url.split(',')
-                        func_1 = lambda *x, urls=urls, name=task.task_name(): [webbrowser.open(url.strip()) for url in
-                                                                               urls]
-                        commands.append(func_1)
-
-                    if file := task.file():
-                        abs_file_path = os.path.abspath(file)
-                        if sys.platform in ('win32',):
-                            func_2 = lambda *x, name=task.task_name(): os.startfile(abs_file_path)
-                        elif sys.platform in ('linux', 'darwin'):
-                            func_2 = lambda *x, name=task.task_name(): os.system(f'xdg-open {abs_file_path}')
-                        commands.append(func_2)
+                    commands = FS.open_task(task.url(), task.name(), task.file(), sys.platform)
 
                     button.setProperty("commands", commands)
 

--- a/src/main.py
+++ b/src/main.py
@@ -692,7 +692,10 @@ class CustomWindow(QWidget):
 
                     if file := task.file():
                         abs_file_path = os.path.abspath(file)
-                        func_2 = lambda *x, name=task.task_name(): os.startfile(abs_file_path)
+                        if sys.platform in ('win32',):
+                            func_2 = lambda *x, name=task.task_name(): os.startfile(abs_file_path)
+                        elif sys.platform in ('linux', 'darwin'):
+                            func_2 = lambda *x, name=task.task_name(): os.system(f'xdg-open {abs_file_path}')
                         commands.append(func_2)
 
                     button.setProperty("commands", commands)

--- a/src/utils/_confirmation_dialog.py
+++ b/src/utils/_confirmation_dialog.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from PyQt5 import QtCore
 from PyQt5.QtWidgets import (
     QWidget,


### PR DESCRIPTION
Changed os.startfile to os.system('xdg-open <file_path>') because os.startfile is a Windows only supported method so that was making the app impossible to run in Linux ans MacOs systems