### PR TITLE
Fix key ID generation to ensure uniqueness in task names (Issue #23)

### DIFF
--- a/src/SaveFile.py
+++ b/src/SaveFile.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Literal, Optional, overload
 import FileSystem as FS
 
 FILE_PATH = FS.SAVE_FILE
+GROUP_ID_DELIMITER = '#'
 
 _save_dict = False
 
@@ -100,6 +101,32 @@ def setting(name: str) -> Any: ...
 def setting(name: str, value: Any) -> None: ...
 # endregion
 
+def _make_unique_id(group_name):
+    ids = []
+    for group in _groups:
+        if remove_group_id(group) == group_name:
+            # Get all group ids with the same name in `ids`
+            ids.append(get_group_id(group))
+    if ids:
+        # If groups with same name exists, add 1 to the last's id
+        return ids[-1] + 1
+    # No groups with same name found so we give `0` for id
+    return 0
+
+def get_group_id(group_name: str, id_delimiter: str = GROUP_ID_DELIMITER) -> int:
+    return int(group_name[group_name.rfind(id_delimiter) + 1])
+
+def remove_group_id(group_name: str, id_delimiter: str = GROUP_ID_DELIMITER) -> str:
+    if id_delimiter in group_name:
+        return group_name[:group_name.rfind(id_delimiter)]
+    return group_name
+
+def give_group_id(group_name: str) -> str:
+    found = 0
+    for group in _groups:
+        if group_name == remove_group_id(group):
+            found += 1
+    return f"{group_name}#{_make_unique_id(group_name)}"
 
 def add_group(group_name: str) -> None:
     global _groups

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -47,7 +47,7 @@ class GroupNode(BaseNode):
         
         self._layout.setContentsMargins(0, 0, 0, 0)
         
-        self._name_label = QLabel(group_name, self)
+        self._name_label = QLabel(Data.remove_group_id(group_name), self)
         self._name_label.setFont(get_font(size=24, weight="semibold"))
 
         new_task_button = GrnButton(self, "radial")
@@ -73,17 +73,17 @@ class GroupNode(BaseNode):
     
     def on_edit_group(self, event) -> None:
         dialog = GroupDialog(self)
-        dialog.for_edit(self._group_name)
+        dialog.for_edit(Data.remove_group_id(self._group_name))
         dialog.setTitle("Edit Group")
         if dialog.exec() != REJECTED:
-            group_name = dialog.result()
+            group_name = Data.give_group_id(dialog.result())
             Data.edit_group(self._group_name, new_group_name=group_name)
-            self._name_label.setText(group_name)
+            self._name_label.setText(Data.remove_group_id(group_name))
             self._parent._nodes[group_name] = self._parent._nodes.pop(self._group_name)
             self._group_name = group_name
     
     def on_delete_group(self, event) -> None:
-        dialog = ConfirmationDialog(f"Delete '{self._group_name}'?", self)
+        dialog = ConfirmationDialog(f"Delete '{Data.remove_group_id(self._group_name)}'?", self)
         if dialog.exec() == ACCEPTED:
             Data.delete_group(self._group_name)
             self.delete()
@@ -166,9 +166,10 @@ class TaskNode(BaseNode):
             self._parent.adjustSize()
 
     def on_delete_task(self, event) -> None:
-        dialog = ConfirmationDialog(f"Delete '{self._task_name}' from '{self._group_node._group_name}'?", self)
+        group_name = self._group_node._group_name
+        dialog = ConfirmationDialog(f"Delete '{self._task_name}' from '{Data.remove_group_id(group_name)}'?", self)
         if dialog.exec() == ACCEPTED:
-            Data.delete_task(self._group_node._group_name, self._task_id)
+            Data.delete_task(group_name, self._task_id)
             self.delete()
     
     def on_text_button(self, evet) -> None:
@@ -291,7 +292,7 @@ class MainWindow(BaseWindow):
     def add_group(self) -> None:
         dialog = GroupDialog(self)
         if dialog.exec() != REJECTED:
-            group_name = dialog.result()
+            group_name = Data.give_group_id(dialog.result())
             Data.add_group(group_name)
             self.create_group(group_name)
 


### PR DESCRIPTION
This PR fixes the issue #23 where the app crashed if two groups with same name were added by adding a unique id at the end of each group name that which will always be invisible from the user